### PR TITLE
Refactor and cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+  - 1.8
+  - tip
+
+script: go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.11
+  - "1.10"
+  - "1.11"
   - tip
 
 script: go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.8
+  - 1.10
+  - 1.11
   - tip
 
 script: go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.10
   - 1.11
   - tip
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Nathaniel Caza
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Add PROXY protocol support to caddy
 
+[![Build Status](https://travis-ci.org/mastercactapus/caddy-proxyprotocol.svg?branch=master)](https://travis-ci.org/mastercactapus/caddy-proxyprotocol)
+
 ## Syntax
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The default timeout is `5s`. Set to `0` or `none` to disable the timeout.
 ## Examples
 
 ```
-# Enable from any source (probably don't want this in prod)
-proxyprotocol 0.0.0.0/0 ::/0
+# Enable from any source 
+proxyprotocol
 
 # Enable from local subnet and fixed IP
 proxyprotocol 10.22.0.0/16 10.23.0.1/32

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Add PROXY protocol support to caddy
+# Add PROXY protocol support to Caddy
 
 [![Build Status](https://travis-ci.org/mastercactapus/caddy-proxyprotocol.svg?branch=master)](https://travis-ci.org/mastercactapus/caddy-proxyprotocol)
 

--- a/listeners.go
+++ b/listeners.go
@@ -19,11 +19,17 @@ func (l *Listener) File() (*os.File, error) { return l.cl.File() }
 func (r ppRules) NewListener(l caddy.Listener) caddy.Listener {
 	if ppL, ok := l.(*Listener); ok {
 		// merge existing
-		ppL.AddRules(r)
+		f := ppL.Filter()
+		f = append(f, r...)
+		ppL.SetFilter(f)
 		return l
 	}
+
+	ppL := pp.NewListener(l, 0)
+	ppL.SetFilter(r)
+
 	return &Listener{
-		Listener: pp.NewListener(l, r),
+		Listener: ppL,
 		cl:       l,
 	}
 }

--- a/setup.go
+++ b/setup.go
@@ -35,6 +35,10 @@ func setup(c *caddy.Controller) error {
 
 func parseConfig(c *caddy.Controller) (cfgs []Config, err error) {
 	for c.Next() {
+		if c.Val() != "proxyprotocol" {
+			continue
+		}
+
 		var cfg Config
 		for _, arg := range c.RemainingArgs() {
 			_, n, err := net.ParseCIDR(arg)

--- a/setup.go
+++ b/setup.go
@@ -4,14 +4,12 @@ import (
 	"net"
 	"time"
 
+	pp "github.com/mastercactapus/proxyprotocol"
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
-type Config struct {
-	Timeout time.Duration
-	Subnets []*net.IPNet
-}
+type ppRules []pp.Rule
 
 func init() {
 	caddy.RegisterPlugin("proxyprotocol", caddy.Plugin{
@@ -21,31 +19,32 @@ func init() {
 }
 
 func setup(c *caddy.Controller) error {
-	configs, err := parseConfig(c)
+	rules, err := parseConfig(c)
 	if err != nil {
 		return err
 	}
 
-	if len(configs) > 0 {
-		httpserver.GetConfig(c).AddListenerMiddleware(Configs(configs).NewListener)
+	if len(rules) > 0 {
+		httpserver.GetConfig(c).AddListenerMiddleware(ppRules(rules).NewListener)
 	}
 
 	return nil
 }
 
-func parseConfig(c *caddy.Controller) (cfgs []Config, err error) {
+func parseConfig(c *caddy.Controller) (cfgs []pp.Rule, err error) {
 	for c.Next() {
 		if c.Val() != "proxyprotocol" {
 			continue
 		}
 
-		var cfg Config
+		var subnets []*net.IPNet
+		var t time.Duration
 		for _, arg := range c.RemainingArgs() {
 			_, n, err := net.ParseCIDR(arg)
 			if err != nil {
 				return nil, err
 			}
-			cfg.Subnets = append(cfg.Subnets, n)
+			subnets = append(subnets, n)
 		}
 
 		if c.NextBlock() {
@@ -54,7 +53,7 @@ func parseConfig(c *caddy.Controller) (cfgs []Config, err error) {
 				if !c.NextArg() {
 					return nil, c.ArgErr()
 				}
-				cfg.Timeout, err = time.ParseDuration(c.Val())
+				t, err = time.ParseDuration(c.Val())
 				if err != nil {
 					return nil, err
 				}
@@ -62,13 +61,15 @@ func parseConfig(c *caddy.Controller) (cfgs []Config, err error) {
 				return nil, c.ArgErr()
 			}
 		}
-		if len(cfg.Subnets) == 0 {
+		if len(subnets) == 0 {
 			continue
 		}
 		if c.NextBlock() {
 			return nil, c.ArgErr()
 		}
-		cfgs = append(cfgs, cfg)
+		for _, n := range subnets {
+			cfgs = append(cfgs, pp.Rule{Subnet: n, Timeout: t})
+		}
 	}
 	return cfgs, nil
 }

--- a/setup.go
+++ b/setup.go
@@ -58,7 +58,7 @@ func parseConfig(c *caddy.Controller) (cfgs []Config, err error) {
 				return nil, c.ArgErr()
 			}
 		}
-		if len(cfg.Subnets) > 0 {
+		if len(cfg.Subnets) == 0 {
 			continue
 		}
 		if c.NextBlock() {

--- a/setup_test.go
+++ b/setup_test.go
@@ -33,25 +33,39 @@ func TestParseConfig(t *testing.T) {
 
 	check(
 		"empty",
-		"",
+		``,
+	)
+	check(
+		"default",
+		`proxyprotocol`,
+		exp{subnet: "0.0.0.0/0", timeout: 5 * time.Second},
+		exp{subnet: "::/0", timeout: 5 * time.Second},
+	)
+	check(
+		"default-options",
+		`proxyprotocol {
+			timeout 1s
+		}`,
+		exp{subnet: "0.0.0.0/0", timeout: time.Second},
+		exp{subnet: "::/0", timeout: time.Second},
 	)
 	check(
 		"single-subnet",
 		`proxyprotocol 127.0.0.1/32`,
-		exp{subnet: "127.0.0.1/32"},
+		exp{subnet: "127.0.0.1/32", timeout: 5 * time.Second},
 	)
 	check(
 		"multi-subnet",
 		`proxyprotocol 0.0.0.0/0 ::/0`,
-		exp{subnet: "0.0.0.0/0"},
-		exp{subnet: "::/0"},
+		exp{subnet: "0.0.0.0/0", timeout: 5 * time.Second},
+		exp{subnet: "::/0", timeout: 5 * time.Second},
 	)
 	check(
 		"duplicate",
 		`proxyprotocol 0.0.0.0/0
 		proxyprotocol ::/0`,
-		exp{subnet: "0.0.0.0/0"},
-		exp{subnet: "::/0"},
+		exp{subnet: "0.0.0.0/0", timeout: 5 * time.Second},
+		exp{subnet: "::/0", timeout: 5 * time.Second},
 	)
 	check(
 		"block-single",
@@ -90,7 +104,7 @@ func TestParseConfig(t *testing.T) {
 				timeout 30m
 			}
 		}`,
-		exp{subnet: "0.0.0.0/0"},
+		exp{subnet: "0.0.0.0/0", timeout: 5 * time.Second},
 		exp{subnet: "1234:300::/24", timeout: 30 * time.Minute},
 	)
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -80,5 +80,17 @@ func TestParseConfig(t *testing.T) {
 		expectedCfg{subnets: []string{"0.0.0.0/0"}, timeout: 25 * time.Minute},
 		expectedCfg{subnets: []string{"1234:300::/24"}, timeout: 30 * time.Minute},
 	)
-
+	check(
+		"multi-site",
+		`example.com {
+			proxyprotocol 0.0.0.0/0
+		}
+		foo.com {
+			proxyprotocol 1234:321::1/24 {
+				timeout 30m
+			}
+		}`,
+		expectedCfg{subnets: []string{"0.0.0.0/0"}},
+		expectedCfg{subnets: []string{"1234:300::/24"}, timeout: 30 * time.Minute},
+	)
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -2,99 +2,83 @@ package proxyprotocol
 
 import (
 	"testing"
-	"github.com/stretchr/testify/assert"
-	"github.com/mholt/caddy"
 	"time"
-	"net"
+
+	"github.com/mholt/caddy"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestProxyprotocolParserOneCDIR(t *testing.T) {
-	c := caddy.NewTestController(
-		"http",
-		`proxyprotocol 127.0.0.1/32`)
-	cfg, err := parse(c)
-	assert.Nil(t, err, "Should not return any erros, receive %v", err)
-	if assert.NotNil(t, cfg, "Config should be set") {
-		_, n, _ := net.ParseCIDR("127.0.0.1/32")
-		assert.Equal(
-			t,
-			time.Duration(0),
-			cfg.Timeout,
-			"Timeout shouldn't be set")
-		assert.Equal(
-			t,
-			[]*net.IPNet{n},
-			cfg.Subnets,
-			"Should get only one subnet")
+func TestParseConfig(t *testing.T) {
+
+	type expectedCfg struct {
+		subnets []string
+		timeout time.Duration
 	}
-}
-//
-func TestProxyprotocolParserWithTimout(t *testing.T) {
-	c := caddy.NewTestController(
-		"http",
+
+	check := func(name, cfg string, expected ...expectedCfg) {
+		t.Run(name, func(t *testing.T) {
+			cfgs, err := parseConfig(caddy.NewTestController("http", cfg))
+			assert.NoError(t, err)
+			assert.Len(t, cfgs, len(expected))
+			for i, exp := range expected {
+				if len(cfgs) <= i {
+					break
+				}
+				cfg := cfgs[i]
+				assert.Len(t, cfg.Subnets, len(exp.subnets))
+				for i, sub := range exp.subnets {
+					assert.Equal(t, sub, cfg.Subnets[i].String(), "Subnet[%d]", i)
+				}
+				assert.Equal(t, exp.timeout.String(), cfg.Timeout.String(), "Timeout")
+			}
+		})
+	}
+
+	check(
+		"empty",
+		"",
+	)
+	check(
+		"single-subnet",
+		`proxyprotocol 127.0.0.1/32`,
+		expectedCfg{subnets: []string{"127.0.0.1/32"}},
+	)
+	check(
+		"multi-subnet",
+		`proxyprotocol 0.0.0.0/0 ::/0`,
+		expectedCfg{subnets: []string{"0.0.0.0/0", "::/0"}},
+	)
+	check(
+		"duplicate",
+		`proxyprotocol 0.0.0.0/0
+		proxyprotocol ::/0`,
+		expectedCfg{subnets: []string{"0.0.0.0/0"}},
+		expectedCfg{subnets: []string{"::/0"}},
+	)
+	check(
+		"block-single",
 		`proxyprotocol 0.0.0.0/0 {
 			timeout 2s
-		}`)
-	cfg, err := parse(c)
-	assert.Nil(t, err, "Should not return any erros, receive %v", err)
-	if assert.NotNil(t, cfg, "Config should be set") {
-		_, n, _ := net.ParseCIDR("0.0.0.0/0")
-		assert.Equal(
-			t,
-			time.Duration(2) * time.Second,
-			cfg.Timeout,
-			"Timeout must be 2s")
-		assert.Equal(
-			t,
-			[]*net.IPNet{n},
-			cfg.Subnets,
-			"Should get only one subnet")
-	}
-}
-
-func TestProxyprotocolMultipleCDIR(t *testing.T) {
-	c := caddy.NewTestController(
-		"http",
-		`proxyprotocol 0.0.0.0/0 ::/0 127.0.0.1/32`)
-	cfg, err := parse(c)
-	assert.Nil(t, err, "Should not return any erros, receive %v", err)
-	if assert.NotNil(t, cfg, "Config should be set") {
-		_, n1, _ := net.ParseCIDR("0.0.0.0/0")
-		_, n2, _ := net.ParseCIDR("::/0")
-		_, n3, _ := net.ParseCIDR("127.0.0.1/32")
-		assert.Equal(
-			t,
-			time.Duration(0),
-			cfg.Timeout,
-			"Timeout shouldn't be set")
-		assert.Equal(
-			t,
-			[]*net.IPNet{n1, n2, n3},
-			cfg.Subnets,
-			"Should get 3 subnet")
-	}
-}
-
-func TestProxyprotocolParserMultipleCDIRWithTimout(t *testing.T) {
-	c := caddy.NewTestController(
-		"http",
+		}`,
+		expectedCfg{subnets: []string{"0.0.0.0/0"}, timeout: 2 * time.Second},
+	)
+	check(
+		"block-multi",
 		`proxyprotocol 0.0.0.0/0 1234:321::1/24 {
 			timeout 25m
-		}`)
-	cfg, err := parse(c)
-	assert.Nil(t, err, "Should not return any erros, receive %v", err)
-	if assert.NotNil(t, cfg, "Config should be set") {
-		_, n1, _ := net.ParseCIDR("0.0.0.0/0")
-		_, n2, _ := net.ParseCIDR("1234:321::1/24")
-		assert.Equal(
-			t,
-			time.Duration(25) * time.Minute,
-			cfg.Timeout,
-			"Timeout must be 25 minutes")
-		assert.Equal(
-			t,
-			[]*net.IPNet{n1, n2},
-			cfg.Subnets,
-			"Should get 2 subnet")
-	}
+		}`,
+		expectedCfg{subnets: []string{"0.0.0.0/0", "1234:300::/24"}, timeout: 25 * time.Minute},
+	)
+	check(
+		"block-duplicate",
+		`proxyprotocol 0.0.0.0/0 {
+			timeout 25m
+		}
+		proxyprotocol 1234:321::1/24 {
+			timeout 30m
+		}`,
+		expectedCfg{subnets: []string{"0.0.0.0/0"}, timeout: 25 * time.Minute},
+		expectedCfg{subnets: []string{"1234:300::/24"}, timeout: 30 * time.Minute},
+	)
+
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,100 @@
+package proxyprotocol
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/mholt/caddy"
+	"time"
+	"net"
+)
+
+func TestProxyprotocolParserOneCDIR(t *testing.T) {
+	c := caddy.NewTestController(
+		"http",
+		`proxyprotocol 127.0.0.1/32`)
+	cfg, err := parse(c)
+	assert.Nil(t, err, "Should not return any erros, receive %v", err)
+	if assert.NotNil(t, cfg, "Config should be set") {
+		_, n, _ := net.ParseCIDR("127.0.0.1/32")
+		assert.Equal(
+			t,
+			time.Duration(0),
+			cfg.Timeout,
+			"Timeout shouldn't be set")
+		assert.Equal(
+			t,
+			[]*net.IPNet{n},
+			cfg.Subnets,
+			"Should get only one subnet")
+	}
+}
+//
+func TestProxyprotocolParserWithTimout(t *testing.T) {
+	c := caddy.NewTestController(
+		"http",
+		`proxyprotocol 0.0.0.0/0 {
+			timeout 2s
+		}`)
+	cfg, err := parse(c)
+	assert.Nil(t, err, "Should not return any erros, receive %v", err)
+	if assert.NotNil(t, cfg, "Config should be set") {
+		_, n, _ := net.ParseCIDR("0.0.0.0/0")
+		assert.Equal(
+			t,
+			time.Duration(2) * time.Second,
+			cfg.Timeout,
+			"Timeout must be 2s")
+		assert.Equal(
+			t,
+			[]*net.IPNet{n},
+			cfg.Subnets,
+			"Should get only one subnet")
+	}
+}
+
+func TestProxyprotocolMultipleCDIR(t *testing.T) {
+	c := caddy.NewTestController(
+		"http",
+		`proxyprotocol 0.0.0.0/0 ::/0 127.0.0.1/32`)
+	cfg, err := parse(c)
+	assert.Nil(t, err, "Should not return any erros, receive %v", err)
+	if assert.NotNil(t, cfg, "Config should be set") {
+		_, n1, _ := net.ParseCIDR("0.0.0.0/0")
+		_, n2, _ := net.ParseCIDR("::/0")
+		_, n3, _ := net.ParseCIDR("127.0.0.1/32")
+		assert.Equal(
+			t,
+			time.Duration(0),
+			cfg.Timeout,
+			"Timeout shouldn't be set")
+		assert.Equal(
+			t,
+			[]*net.IPNet{n1, n2, n3},
+			cfg.Subnets,
+			"Should get 3 subnet")
+	}
+}
+
+func TestProxyprotocolParserMultipleCDIRWithTimout(t *testing.T) {
+	c := caddy.NewTestController(
+		"http",
+		`proxyprotocol 0.0.0.0/0 1234:321::1/24 {
+			timeout 25m
+		}`)
+	cfg, err := parse(c)
+	assert.Nil(t, err, "Should not return any erros, receive %v", err)
+	if assert.NotNil(t, cfg, "Config should be set") {
+		_, n1, _ := net.ParseCIDR("0.0.0.0/0")
+		_, n2, _ := net.ParseCIDR("1234:321::1/24")
+		assert.Equal(
+			t,
+			time.Duration(25) * time.Minute,
+			cfg.Timeout,
+			"Timeout must be 25 minutes")
+		assert.Equal(
+			t,
+			[]*net.IPNet{n1, n2},
+			cfg.Subnets,
+			"Should get 2 subnet")
+	}
+}


### PR DESCRIPTION
Includes commits from https://github.com/mastercactapus/caddy-proxyprotocol/pull/1

- Added tests
- Adds V2 support
- Merge multiple middleware instances (fixes #3)
- Fix parsing issues (some examples in README were broken)
- Default is to require all connections to provide PROXY header (same as HAProxy)
- Match subnets-to-timeouts based on specificity, rather than parse order.
